### PR TITLE
Workflow to publish failed because dependancies

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   publish-npm:
-    needs: unit-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This fix is fine because all merges are required to pass tests to even be considered for a publish